### PR TITLE
Fix monster index bounds and health update

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ void healthSystem();
 
 // Globals
 Monster mnst[50];
-int lvl = 1;
+int lvl = 0;
 
 // Update Function
 void Update()
@@ -36,9 +36,9 @@ int main()
     ToggleFullscreen();
 
     // Initializing Monsters
-    for (int i = 1; i <= 50; i++)
+    for (int i = 0; i < 50; i++)
     {
-        mnst[i].createMonster(i, i * 100);
+        mnst[i].createMonster(i + 1, (i + 1) * 100);
         mnst[i].screendimension(ScreenWidth, ScreenHeight);
     }
 
@@ -55,7 +55,7 @@ int main()
     }
 
     // Cleaning
-    for (int i = 1; i <= 50; i++)
+    for (int i = 0; i < 50; i++)
     {
         UnloadTexture(mnst[i].monsterTexture());
     }
@@ -69,7 +69,7 @@ int main()
 
 void drawElements()
 {
-    if (lvl == mnst[lvl].monsterNumber())
+    if (lvl + 1 == mnst[lvl].monsterNumber())
     {
         mnst[lvl].drawRes();
     }
@@ -85,7 +85,7 @@ void Controls()
 
 void healthSystem()
 {
-    if (mnst[lvl].monsterHealth() == 0)
+    if (mnst[lvl].monsterHealth() == 0 && lvl < 49)
     {
         lvl++;
     }

--- a/res/items.h
+++ b/res/items.h
@@ -82,7 +82,7 @@ public:
         return health;
     }
 
-    int monsterHealthchanger(int he_lth)
+    void monsterHealthchanger(int he_lth)
     {
         health = he_lth;
     }


### PR DESCRIPTION
## Summary
- initialize starting level from 0
- iterate monsters using indices 0-49
- prevent out-of-bounds in `healthSystem`
- change `monsterHealthchanger` to return `void`

## Testing
- `g++ -std=c++17 -I./ -o main_new.out main.cpp -lraylib` *(fails: raylib not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842634d32148330bd937eb8acf75108